### PR TITLE
Add SvelteUI Pro

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ A curated list of awesome things related to <a href='https://shadcn-svelte.com/'
 | `shadcn/studio-svelte`  | shadcn/studio, but for Svelte. ✨                                                              | [Link](https://github.com/EpicAlbin03/shadcn-studio-svelte) |
 | `Svelte Image Uploader` | Svelte image uploader with dnd, validation and previews                                        | [Link](https://svelte-image-uploader.vercel.app)            |
 | `svelte-tablecn`        | A powerful, feature-rich data grid component for Svelte 5.                                     | [Link](https://github.com/itisyb/svelte-tablecn)            |
+| `SvelteUI Pro`          | 45+ production-ready Svelte 5 components built with Tailwind CSS 4 and runes reactivity        | [Link](https://ui.shanecode.org)                             |
 
 ## Apps
 


### PR DESCRIPTION
Adds [SvelteUI Pro](https://ui.shanecode.org) to the **Libs and Components** section.

**SvelteUI Pro** is a collection of 45+ production-ready Svelte 5 components built with Tailwind CSS 4 and runes reactivity — buttons, forms, modals, tables, charts, navigation, and more. It includes a free tier with 11 components.

It follows a copy-paste component model similar to shadcn-svelte, providing additional production-ready components for the ecosystem.

- Placed alphabetically in the existing table
- Matches the existing table format